### PR TITLE
Change comic bar artwork position

### DIFF
--- a/assets/css/master.css
+++ b/assets/css/master.css
@@ -26,7 +26,7 @@
     z-index: 1;
     opacity: 0.6;
     background-repeat: no-repeat;
-    background-position: 50% 0;
+    background-position: 50% 25%;
     -ms-background-size: cover;
     -o-background-size: cover;
     -moz-background-size: cover;


### PR DESCRIPTION
Adjusts the background-position of the comic bars in the various lists of comics so that an area slightly closer to the vertical middle is visible.

Characters' faces in the various comic banners tend to be around 1/3 of the way down (and logos tend to be a little higher, or much lower), and having the background y position somewhere around 25%~33% increases the chance that these and other eye-catching elements from the banner are actually in the comic bars, whereas the top section of the background that's currently displayed is often pretty dull.

There's of course no one value that works for every banner, but from my testing, 25% looks better than 0% on the majority of banners.